### PR TITLE
Java-hakkerointi -artikkeli + paremmat code blockit :D

### DIFF
--- a/paper/java-hakkerointi/1.md
+++ b/paper/java-hakkerointi/1.md
@@ -116,4 +116,4 @@ Saamme seuraavan tuloksen:
 ```
 Jippii, se toimi! jdk.internal.misc.Unsafe@37a71e93
 ```
-Overlordin avulla voimme siis rikkoa moduulien luoman enkapsulaatiojärjestelmän, joka mahdollistaa reflektion kautta Javan yksityisten luokkajäsenien käytön
+Overlordin avulla voimme siis rikkoa moduulien luoman enkapsulaatiojärjestelmän, joka mahdollistaa reflektion kautta Javan yksityisten luokkajäsenien käytön.

--- a/paper/java-hakkerointi/1.md
+++ b/paper/java-hakkerointi/1.md
@@ -6,7 +6,7 @@ Java on eliöpohjainen kieli, jossa luokkien, muuttujien ja metodien saatavuutta
 
 Mutta entäs jos joku datanomi on tehnyt muuttujasta tai metodista yksityisen, ja meidän nerokas ohjelmistomme tarvitsee käyttöoikeuksia siihen?
 
-Tarvitsemme jonkun tavan käyttää Javassa yksityisesti merkittyjä muuttujia ilman lupaa. Onneksi Javan kehittäjät ovat antaneet meille työkalun, jolla voimme päästä käsiksi yksityiseksi merkittyihin luokkiin ja luokkien jäseniin: Reflektion.
+Tarvitsemme jonkun tavan käyttää Javassa yksityiseksi merkittyjä muuttujia ilman lupaa. Onneksi Javan kehittäjät ovat antaneet meille työkalun, jolla voimme päästä käsiksi yksityiseksi merkittyihin luokkiin ja luokkien jäseniin: Reflektion.
 
 ## Java-reflektion ihmeellinen maailma
 

--- a/paper/java-hakkerointi/1.md
+++ b/paper/java-hakkerointi/1.md
@@ -1,0 +1,119 @@
+# Java-hakkerointi
+
+Java on eliöpohjainen kieli, jossa luokkien, muuttujien ja metodien saatavuutta ilmaistaan pääasiassa kahdella eri tavalla:
+- Saatavuusdeklaraatiot (`private`, `protected`, `public`, yms.)
+- Moduulit (`module-info.java`)
+
+Mutta entäs jos joku datanomi on tehnyt muuttujasta tai metodista yksityisen, ja meidän nerokas ohjelmistomme tarvitsee käyttöoikeuksia siihen?
+
+Tarvitsemme jonkun tavan käyttää Javassa yksityisesti merkittyjä muuttujia ilman lupaa. Onneksi Javan kehittäjät ovat antaneet meille työkalun, jolla voimme päästä käsiksi yksityiseksi merkittyihin luokkiin ja luokkien jäseniin: Reflektion.
+
+## Java-reflektion ihmeellinen maailma
+
+Kuvittele, että joku huono ikävä ihminen on kirjoittanut luokan `A`:
+```java
+public class A {
+    private static int treasure = 69420;
+}
+```
+Haluaisimme saada `A`-luokan `treasure`-muuttujan arvon, mutta se on merkitty yksityiseksi! Mitäs nyt? Käytämme reflektiota:
+```java
+import java.lang.reflect.Field;
+
+public class B {
+    public static void main(String[] args) {
+        // stupid A
+        try {
+            Field treasureField = A.class.getDeclaredField("treasure");
+            treasureField.trySetAccessible();
+
+            // hehe we get treasure ! :)
+            System.out.println(
+                treasureField.get(null)
+            );
+        } catch (Exception ex) {
+            System.err.println("Voi ei!");
+            ex.printStackTrace();
+        }
+    }
+}
+```
+B-luokka saa reflektion avulla A-luokan `treasure`-muuttujan arvon, vaikka se on merkitty yksityiseksi.
+
+
+## Project Jigsaw
+
+Javan versiossa 9 lisättiin Jigsaw-projektin myötä moduulit, jotka antoivat ohjelmiston kehittäjille mahdollisuuden määrittää, kuka pystyy käyttämään tiettyä osaa ohjelmistosta. Ikävä kyllä Javan sisäinen koodi käyttää näitä moduuleja estääkseen tuntematonta koodia käyttämästä reflektion avulla Javan omien luokkien yksityisiä jäseniä.
+
+Kokeillaan samaa reflektio-metodia, mutta yritetään B-luokan sijasta suorittaa `Unsafe.getUnsafe()` -metodi:
+
+```java
+import java.lang.reflect.Method;
+
+public class B {
+    public static void main(String[] args) {
+        try {
+            Class<?> unsafeClass = Class.forName("jdk.internal.misc.Unsafe");
+            Method getUnsafeMethod = unsafeClass.getDeclaredMethod("getUnsafe");
+            getUnsafeMethod.trySetAccessible();
+
+            Object unsafe = getUnsafeMethod.invoke(null);
+            System.out.println("Jippii, se toimi! " + unsafe);
+        } catch (Exception ex) {
+            System.err.println("Voi ei!");
+            ex.printStackTrace();
+        }
+    }
+}
+```
+
+Kun yritämme suorittaa B-ohjelman, saamme Javalta seuraavan virheen:
+```
+Voi ei!
+java.lang.IllegalAccessException: class B cannot access class jdk.internal.misc.Unsafe (in module java.base) because module java.base does not export jdk.internal.misc to unnamed module @3fee733d
+        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:392)
+        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:674)
+        at java.base/java.lang.reflect.Method.invoke(Method.java:560)
+        at B.main(B.java:10)
+```
+
+Ikävä kyllä `java.base` -moduuli estää meitä käyttämästä `jdk.internal.misc` -pakettia. Kuitenkin kaikkeen on keinonsa, ja lievällä hakkeroinnilla saadaan kyllä Javan sisäinenkin koodi taipumaan tahtoomme.
+
+Monet Javan käyttäjät kokivat moduulien lisäämät rajoitukset ikäviksi. Rajoitusten ohi pääsemiseen on luotu kirjastoja, kuten esimerkiksi [Overlord](https://github.com/Moderocky/Overlord).
+
+## Overlord, destroyer of Encapsulation
+
+Overlord-kirjastolla voimme rikkoa Jigsawin luoman enkapsulaation kokonaan, ja saada oikeudet käyttää reflektiota metodin suorittamiseen.
+
+Käytetään tismalleen samaa koodia kuin äsken, mutta lisätään Overlordin `breakEncapsulation` ja `allowAccess` -metodit:
+
+```java
+import java.lang.reflect.Method;
+import mx.kenzie.overlord.Overlord;
+
+public class B {
+    public static void main(String[] args) {
+        try {
+            Class<?> unsafeClass = Class.forName("jdk.internal.misc.Unsafe");
+
+            Overlord.breakEncapsulation(B.class, unsafeClass, true);
+            Overlord.allowAccess(B.class, unsafeClass, true);
+
+            Method getUnsafeMethod = unsafeClass.getDeclaredMethod("getUnsafe");
+            getUnsafeMethod.trySetAccessible();
+
+            Object unsafe = getUnsafeMethod.invoke(null);
+            System.out.println("Jippii, se toimi! " + unsafe);
+        } catch (Exception ex) {
+            System.err.println("Voi ei!");
+            ex.printStackTrace();
+        }
+    }
+}
+```
+
+Saamme seuraavan tuloksen:
+```
+Jippii, se toimi! jdk.internal.misc.Unsafe@37a71e93
+```
+Overlordin avulla voimme siis rikkoa moduulien luoman enkapsulaatiojärjestelmän, joka mahdollistaa reflektion kautta Javan yksityisten luokkajäsenien käytön

--- a/paper/java-hakkerointi/1.md
+++ b/paper/java-hakkerointi/1.md
@@ -77,7 +77,7 @@ java.lang.IllegalAccessException: class B cannot access class jdk.internal.misc.
         at B.main(B.java:10)
 ```
 
-Ikävä kyllä `java.base` -moduuli estää meitä käyttämästä `jdk.internal.misc` -pakettia. Kuitenkin kaikkeen on keinonsa, ja lievällä hakkeroinnilla saadaan kyllä Javan sisäinenkin koodi taipumaan tahtoomme.
+Ikävä kyllä `java.base` -moduuli estää meitä käyttämästä `jdk.internal.misc` -pakettia. Kuitenkin kaikkeen on keinonsa, ja lievällä hakkeroinnilla saamme kyllä Javan sisäisenkin koodin taipumaan tahtoomme.
 
 Monet Javan käyttäjät kokivat moduulien lisäämät rajoitukset ikäviksi. Rajoitusten ohi pääsemiseen on luotu kirjastoja, kuten esimerkiksi [Overlord](https://github.com/Moderocky/Overlord).
 

--- a/paper/java-hakkerointi/meta.json
+++ b/paper/java-hakkerointi/meta.json
@@ -1,0 +1,5 @@
+{
+    "title": "Java-hakkerointi - Poistetaan suojaukset",
+    "description": "Tutkitaan, miten se enkapsulaatio rikotaan",
+    "author": "Ilari"
+}

--- a/src/style.css
+++ b/src/style.css
@@ -58,17 +58,24 @@ a:hover {
 
 code {
     background-color: #0d0f17;
-    border-radius: 8px;
     color: #BCF8EC;
     overflow-wrap: normal;
-    padding: 8px;
     font-family: 'Ubuntu Mono', monospace;
     font-size: 80%;
     display: inline;
 }
 
+code {
+    padding: 2px;
+    border-radius: 2px;
+}
+
 pre code {
     display: block;
+    overflow: auto !important;
+    background-attachment: fixed !important;
+    padding: 8px;
+    border-radius: 8px;
 }
 
 pre,


### PR DESCRIPTION
Tämä PR luo uuden artikkelin, joka käsittelee Javan enkapsulaation ja luokkajäsenyksityisyyden rikkomista reflektion ja Overlord-kirjaston avulla. Sen lisäksi PR lisää code-blockkeihin `overflow: auto; background-attachment: fixed;` tyylin, jolloin blockit eivät valu seuraaviin kolumneihin, vaan niihin ilmestyy tarvittaessa vierityspalkki.

Alla olevassa esikatselussa näkyy uusi artikkeli sekä parannellut code-blockit, joissa inline code-blockkien reuna on vähemmän pyöristetty ja vierityspalkit toimivat.

![Sivun esikatselu](https://user-images.githubusercontent.com/52505120/136695605-60809dde-0022-48e5-bcf6-da70ad7ddbb3.png)
